### PR TITLE
Fix multiple deliveries of commands

### DIFF
--- a/TC/src/main/java/de/fraunhofer/iosb/testrunner/JMSTestRunner.java
+++ b/TC/src/main/java/de/fraunhofer/iosb/testrunner/JMSTestRunner.java
@@ -113,6 +113,12 @@ public class JMSTestRunner extends TestRunner implements MessageListener {
     					String commandTypeName =  (String) jsonObject.get("commandType");
     					System.out.println("The commandType name is: " + commandTypeName);
     					if (commandTypeName.equals("startTestCase")) {
+    						Long temp = Long.valueOf((String)jsonObject.get("sequence"));
+    						if (temp == null) {
+    							System.out.println("The sequence number is: null");
+    						} else {
+    							counter = temp.intValue();
+    						}
     						testCaseId = (String) jsonObject.get("testCaseId");
     						System.out.println("The test case class is: " + testCaseId);
     						testCaseParam = (JSONObject) jsonObject.get("tcParam");

--- a/UI/src/main/java/de/fraunhofer/iosb/ivct/AbortConformanceTest.java
+++ b/UI/src/main/java/de/fraunhofer/iosb/ivct/AbortConformanceTest.java
@@ -29,7 +29,7 @@ public class AbortConformanceTest implements Command {
 	}
 
 	public void execute() {
-		String unsetConformanceTestString = IVCTcommander.printJson("abortConformanceTest", this.counter);
-		this.ivctCommander.sendToJms(unsetConformanceTestString);
+		String abortConformanceTestString = IVCTcommander.printJson("{ \"commandType\" : \"abortConformanceTest\" }", this.counter);
+		this.ivctCommander.sendToJms(abortConformanceTestString);
 	}
 }

--- a/UI/src/main/java/de/fraunhofer/iosb/ivct/CmdLineTool.java
+++ b/UI/src/main/java/de/fraunhofer/iosb/ivct/CmdLineTool.java
@@ -38,7 +38,7 @@ public class CmdLineTool {
 	private static final int DEFAULT_PORT = 6789;
 	public static int counter = 0;
 //    Socket socket;
-    Thread reader, writer;
+    Thread writer;
     private static String hostname = null;
     protected static boolean conformanceTestBool = false;
     protected static String sutName = null;
@@ -48,20 +48,15 @@ public class CmdLineTool {
     private static int port = DEFAULT_PORT;
     public static IVCTcommander ivctCommander;
 
-    // Create the client by creating its reader and writer threads
+    // Create the client by creating a writer thread
     // and starting them.
     public CmdLineTool(String host, int port) {
 //            socket = new Socket(host, port);
-            // Create reader and writer sockets
+            // Create writer socket
             
-            reader = new Reader(this);
             writer = new Writer(this);
-            // Give the reader a higher priority to work around
-            // a problem with shared access to the console.
-            reader.setPriority(6);
             writer.setPriority(5);
-            // Start the threads 
-            reader.start();
+            // Start the thread
             writer.start();
     }
 
@@ -133,29 +128,7 @@ public class CmdLineTool {
     	handleArgs(args);
 
         new CmdLineTool(hostname, port);
-    }
-}
-
-// This thread reads data from the server and prints it on the console
-// As usual, the run() method does the interesting stuff.
-class Reader extends Thread {
-    CmdLineTool client;
-    public Reader(CmdLineTool c) {
-        super("CmdLineTool Reader");
-        this.client = c;
-    }
-    public void run() {
-      for (int i = 0; i < 1000000; i++)
-      {
-//        System.out.println("Loop: " + i);
-        try {
-        	CmdLineTool.ivctCommander.listenToJms();
-            Thread.sleep(100);
-        }
-        catch (InterruptedException ex) {
-        }
-      }
-        System.exit(0);
+    	CmdLineTool.ivctCommander.listenToJms();
     }
 }
 

--- a/UI/src/main/java/de/fraunhofer/iosb/ivct/StartConformanceTest.java
+++ b/UI/src/main/java/de/fraunhofer/iosb/ivct/StartConformanceTest.java
@@ -29,7 +29,7 @@ public class StartConformanceTest implements Command {
 	}
 
 	public void execute() {
-		String setConformanceTestString = IVCTcommander.printJson("startConformanceTest", this.counter);
+		String setConformanceTestString = IVCTcommander.printJson("{ \"commandType\" : \"startConformanceTest\" }", this.counter);
 		this.ivctCommander.sendToJms(setConformanceTestString);
 	}
 }


### PR DESCRIPTION
The listenToJms method was being called in a loop which generated a new
listener for each cycle causing a large number of duplicate commands.
The method is only being called once now.