### PR TITLE
Added a create SUT command.

### DIFF
--- a/Command/src/main/java/nato/ivct/commander/BadgeTcParam.java
+++ b/Command/src/main/java/nato/ivct/commander/BadgeTcParam.java
@@ -1,5 +1,4 @@
-/*
-Copyright 2016, Johannes Mulder (Fraunhofer IOSB)
+/* Copyright 2018, Johannes Mulder (Fraunhofer IOSB)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,11 +10,14 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.
-*/
+limitations under the License. */
 
-package de.fraunhofer.iosb.ivct;
+package nato.ivct.commander;
 
-public interface Command {
-	void execute();
+import org.json.simple.JSONObject;
+
+// The badge with its TcParam name/value pairs
+public class BadgeTcParam {
+		public String id;
+		public JSONObject tcParam;
 }

--- a/Command/src/main/java/nato/ivct/commander/CmdListSuT.java
+++ b/Command/src/main/java/nato/ivct/commander/CmdListSuT.java
@@ -44,11 +44,13 @@ public class CmdListSuT implements Command {
 		File[] filesList = dir.listFiles();
 		for (File file : filesList) {
 			if (file.isDirectory()) {
+				FileReader fReader = null;
 				Object obj;
 				JSONParser parser = new JSONParser();
 				try {
 					SutDescription sut = new SutDescription();
-					obj = parser.parse(new FileReader(file + "/CS.json"));
+					fReader = new FileReader(file + "/CS.json");
+					obj = parser.parse(fReader);
 					JSONObject jsonObj = (JSONObject) obj;
 					sut.ID = (String) jsonObj.get("id");
 					sut.description = (String) jsonObj.get("description");
@@ -62,6 +64,15 @@ public class CmdListSuT implements Command {
 				} catch (IOException | ParseException e) {
 					// TODO Auto-generated catch block
 					e.printStackTrace();
+				} finally {
+					if (fReader != null) {
+						try {
+							fReader.close();
+						} catch (IOException e) {
+							// TODO Auto-generated catch block
+							e.printStackTrace();
+						}
+					}
 				}
 
 			}

--- a/Command/src/main/java/nato/ivct/commander/CmdUpdateSUT.java
+++ b/Command/src/main/java/nato/ivct/commander/CmdUpdateSUT.java
@@ -326,18 +326,21 @@ public class CmdUpdateSUT implements Command {
 				}
 				// get badge files list from the JSON object
 				JSONArray badgeArray = (JSONArray) jsonObject.get("badge");
-				if (badgeTcParams.length > 0) {
+				if (badgeTcParams != null) {
 					if (badgeArray != null) {
-						if (badgeTcParams != null) {
-							for (int i = 0; i < badgeTcParams.length; i++) {
-								if (badgeArray.contains(badgeTcParams[i].id)) {
-									continue;
+						if (badgeTcParams.length == badgeArray.size()) {
+							if (badgeTcParams.length > 0) {
+								for (int i = 0; i < badgeTcParams.length; i++) {
+									if (badgeArray.contains(badgeTcParams[i].id)) {
+										continue;
+									}
+									dataChanged = true;
 								}
-								dataChanged = true;
 							}
+						} else {
+							dataChanged = true;
 						}
 					}
-					String entry;
 					for (int i = 0; i < badgeArray.size(); i++) {
 						for (int j = 0; j < badgeTcParams.length; j++) {
 							if (badgeTcParams[j].id.equals(badgeArray.get(i))) {

--- a/Command/src/main/java/nato/ivct/commander/CmdUpdateSUT.java
+++ b/Command/src/main/java/nato/ivct/commander/CmdUpdateSUT.java
@@ -1,0 +1,416 @@
+/* Copyright 2018, Johannes Mulder (Fraunhofer IOSB)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+package nato.ivct.commander;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CmdUpdateSUT implements Command {
+
+    private static Logger logger = LoggerFactory.getLogger(CmdUpdateSUT.class);
+	private String sutId;
+	private String sutDescription;
+	private String vendorName;
+	private BadgeTcParam[] badgeTcParams;
+	private static Map<String, URL[]> badgeURLs = new HashMap<String, URL[]>();
+	private static CmdListBadges badges;
+
+	/**
+	 * 
+	 * @param sutId the SUT identifier
+	 * @param sutDescription the SUT description
+	 * @param vendorName the vendor name
+	 * @param badgeTcParams the full list of badge names and optionally TcParams
+	 */
+	public CmdUpdateSUT(final String sutId, final String sutDescription, final String vendorName, final BadgeTcParam[] badgeTcParams) {
+		this.sutId = sutId;
+		this.sutDescription = sutDescription;
+		this.vendorName = vendorName;
+		this.badgeTcParams = badgeTcParams;
+		// get the badge descriptions
+		badges = new CmdListBadges();
+		badges.execute();
+	}
+
+	/**
+	 * 
+	 * @param badge the required badge
+	 */
+	private static URL[] getBadgeUrls(final String badge) throws Exception {
+		logger.trace(badge);
+		URL[] myBadgeURLs = badgeURLs.get(badge);
+		if (myBadgeURLs == null) {
+			BadgeDescription bd = badges.badgeMap.get(badge);
+			if (bd != null) {
+				String ts_path = Factory.props.getProperty(Factory.IVCT_TS_HOME_ID);
+				logger.trace(ts_path);
+				if (bd.tsLibTimeFolder != null) {
+					String lib_path = ts_path + "/" + bd.tsLibTimeFolder;
+					logger.trace(lib_path);
+					File dir = new File(lib_path);
+					File[] filesList = dir.listFiles();
+					URL[] urls = new URL[filesList.length];
+					for (int i = 0; i < filesList.length; i++) {
+						try {
+							urls[i] = filesList[i].toURI().toURL();
+						} catch (MalformedURLException e) {
+							e.printStackTrace();
+						}
+					}
+					badgeURLs.put(badge, urls);
+					return urls;
+				}
+			} else {
+				throw new Exception("getBadgeUrls unknown badge: " + badge);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * This method will extract a resource from a known badge resource location to
+	 * a specified directory
+	 * 
+	 * @param badge the name of the badge of the resource required
+	 * @param dirName the name of the directory where the resource should be copied to
+	 * @param resourceName the name of the resource
+	 * @return false means file already exists or was extracted - NO overwrite
+	 *         true means error
+	 */
+	private static boolean extractResource(String badge, String dirName, String resourceName) throws Exception {
+
+		// Check if dirName exists and is a directory
+		File d = new File(dirName);
+		if (d.exists() && !d.isDirectory()) {
+			throw new Exception("Target directory does not exist or is not a directory: " + dirName);
+		}
+
+		// If the desired file exists, do not overwrite
+		File f = new File(dirName + "/" + resourceName);
+		if (f.exists()) { 
+			if (f.isDirectory()) {
+				throw new Exception("Target resource is a directory: " + dirName + "/" + resourceName);
+			}
+			return false;
+		}
+
+		// Work through the list of badge jar/text url sources
+		URL[] myBadgeURLs = getBadgeUrls(badge);
+		if (myBadgeURLs == null) {
+			throw new Exception("Unknown badge: " + badge);
+		}
+		for (int i = 0; i < myBadgeURLs.length; i++) {
+			try {
+				int pos = myBadgeURLs[i].getFile().lastIndexOf('/');
+				if (resourceName.equals(myBadgeURLs[i].getFile().substring(pos + 1))) {
+					java.io.InputStream is = new java.io.FileInputStream(myBadgeURLs[i].getFile());
+					String outputFileString = new String(dirName + "/" + resourceName);
+					java.io.FileOutputStream fo = new java.io.FileOutputStream(outputFileString);
+					byte[] buffer = new byte[1024];
+					int length;
+					while ((length = is.read(buffer)) > 0) {
+						fo.write(buffer, 0, length);
+					}
+					fo.close();
+					is.close();
+					break;
+				} else {
+					pos = myBadgeURLs[i].getFile().lastIndexOf('.');
+					if (".jar".equals(myBadgeURLs[i].getFile().substring(pos))) {
+						if (extractFromJar(dirName, resourceName, myBadgeURLs[i].getFile())) {
+							break;
+						}
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+				throw new Exception("extractResource: IOException");
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * This function will extract a named file from a named jar file and
+	 * copy it to the destination directory
+	 * 
+	 * @param destdir the destination directory
+	 * @param extractFileName the required file name to be extracted
+	 * @param jarFileName the name of the jar to search
+	 * @return true if file found, false if file found
+	 * @throws java.io.IOException if problem with the file.
+	 */
+	private static boolean extractFromJar(final String destdir, final String extractFileName, final String jarFileName) throws java.io.IOException {
+		boolean found = false;
+		java.util.jar.JarFile jarfile = new java.util.jar.JarFile(new java.io.File(jarFileName)); //jar file path(here sqljdbc4.jar)
+		java.util.Enumeration<java.util.jar.JarEntry> enu= jarfile.entries();
+		while(enu.hasMoreElements())
+		{
+			java.util.jar.JarEntry je = enu.nextElement();
+
+			logger.trace(je.getName());
+			if (je.getName().equals(extractFileName) == false) {
+				continue;
+			}
+			logger.trace("GOT THE FILE");
+			found = true;
+
+			java.io.File fl = new java.io.File(destdir, je.getName());
+			if(fl.exists()) {
+				break;
+			}
+			if(!fl.exists())
+			{
+				fl.getParentFile().mkdirs();
+				fl = new java.io.File(destdir, je.getName());
+			}
+			if(je.isDirectory())
+			{
+				continue;
+			}
+			java.io.InputStream is = jarfile.getInputStream(je);
+			java.io.FileOutputStream fo = new java.io.FileOutputStream(fl);
+			byte[] buffer = new byte[1024];
+			int length;
+			while ((length = is.read(buffer)) > 0) {
+				fo.write(buffer, 0, length);
+			}
+			fo.close();
+			is.close();
+			break;
+		}
+		jarfile.close();
+		return found;
+
+	}
+
+	/**
+	 * Not all badges refer to a test suite with TcParams: some
+	 * badges are only containers, thus take only badges with TcParams.json
+	 * files.
+	 * 
+	 * @param testsuites the set of test suites
+	 * @param badge the current badge name being processed
+	 */
+	void buildTestsuiteSet(Set<String> testsuites, final String badge) {
+		BadgeDescription bd = badges.badgeMap.get(badge);
+		if (bd != null) {
+			if (bd.tsLibTimeFolder != null) {
+				testsuites.add(badge);
+			}
+			for (int i = 0; i < bd.dependency.length; i++) {
+				buildTestsuiteSet(testsuites, bd.dependency[i]);
+			}
+		}
+	}
+
+	@Override
+	public void execute() throws Exception {
+		// The SUT is placed in a known folder
+		String sutsDir = Factory.props.getProperty(Factory.IVCT_SUT_HOME_ID);
+		String sutDir = sutsDir + "/" + sutId;
+		File f = new File(sutDir);
+		if (f.exists() == false) {
+			if (f.mkdir() == false) {
+				logger.error("Failed to create directory: " + sutDir);
+			}
+		}
+
+		Set<String> testsuites = new HashSet<>();
+		// Check if no badges
+		if (this.badgeTcParams != null) {
+			
+			// For each badge, check if there is a testsuite with TcParams
+			for (int i = 0; i < this.badgeTcParams.length; i++) {
+				buildTestsuiteSet(testsuites, this.badgeTcParams[i].id);
+			}
+			
+
+			// For each test suite copy or modify the TcParam.json file
+			for (String testsuite : testsuites) {
+				// Add badge folder
+				String sutBadge = sutDir + "/" + testsuite;
+				f = new File(sutBadge);
+				if (f.exists() == false) {
+					if (f.mkdir() == false) {
+						logger.trace("Failed to create directory!");
+					}
+				}
+
+				// This is the file to copy
+				if (extractResource(testsuite, sutBadge, "TcParam.json")) {
+					throw new Exception("extractResource: Error occured!");
+				}
+			}
+		}
+
+		// If CS.json exists, only change what is different
+		boolean dataChanged = false;
+		String csJsonFileName = new String(sutDir + "/" + "CS.json");
+		StringBuilder sb = new StringBuilder();
+		File cs = new File(csJsonFileName);
+		if (cs.exists() && cs.isFile()) {
+			FileReader fr = null;
+			try {
+				fr = new FileReader(csJsonFileName);
+				BufferedReader br = new BufferedReader(fr);
+				String s;
+				while((s = br.readLine()) != null) {
+					sb.append(s);
+				}
+				fr.close(); 
+			} catch (IOException e) {
+				e.printStackTrace();
+				throw new Exception("execute: IOException" + csJsonFileName);
+			} finally {
+				if (fr != null) {
+					try {
+						fr.close();
+					} catch (IOException e) {
+						e.printStackTrace();
+						throw new Exception("execute: file close: IOException");
+					}
+				}
+			}
+			JSONParser jsonParser = new JSONParser();
+			JSONObject jsonObject;
+			try {
+				jsonObject = (JSONObject) jsonParser.parse(sb.toString());
+				// get a String from the JSON object
+				String oldSUTname = (String) jsonObject.get("id");
+				if (oldSUTname != null) {
+					if (oldSUTname.equals(this.sutId) == false) {
+						dataChanged = true;
+					}
+				}
+				// get a String from the JSON object
+				String oldDescription = (String) jsonObject.get("description");
+				if (oldDescription != null) {
+					if (oldDescription.equals(this.sutDescription) == false) {
+						dataChanged = true;
+					}
+				}
+				// get a String from the JSON object
+				String oldVendor = (String) jsonObject.get("vendor");
+				if (oldVendor != null) {
+					if (oldVendor.equals(this.vendorName) == false) {
+						dataChanged = true;
+					}
+				}
+				// get badge files list from the JSON object
+				JSONArray badgeArray = (JSONArray) jsonObject.get("badge");
+				if (badgeTcParams.length > 0) {
+					if (badgeArray != null) {
+						if (badgeTcParams != null) {
+							for (int i = 0; i < badgeTcParams.length; i++) {
+								if (badgeArray.contains(badgeTcParams[i].id)) {
+									continue;
+								}
+								dataChanged = true;
+							}
+						}
+					}
+					String entry;
+					for (int i = 0; i < badgeArray.size(); i++) {
+						for (int j = 0; j < badgeTcParams.length; j++) {
+							if (badgeTcParams[j].id.equals(badgeArray.get(i))) {
+								continue;
+							}
+							dataChanged = true;
+							break;
+						}
+						if (dataChanged) {
+							break;
+						}
+
+					}
+				} else {
+					if (badgeArray.size() > 0) {
+						dataChanged = true;
+					}
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+				throw new Exception("execute: Exception");
+			}
+		} else {
+			if (cs.isDirectory()) {
+				return;
+			} else {
+				// New data
+				dataChanged = true;
+			}
+		}
+		
+		if (dataChanged == false) {
+			return;
+		}
+
+		// Update CS.json file
+        JSONObject obj = new JSONObject();
+        obj.put("id", this.sutId);
+        obj.put("description", this.sutDescription);
+        obj.put("vendor", this.vendorName);
+
+        JSONArray list = new JSONArray();
+        if (badgeTcParams != null) {
+        	int len = this.badgeTcParams.length;
+        	for (int i = 0; i < len; i++) {
+                list.add(this.badgeTcParams[i].id);
+//        list.add("msg 1");
+//        list.add("msg 2");
+//        list.add("msg 3");
+        	}
+        }
+
+        obj.put("badge", list);
+
+        FileWriter fw = null;
+        try {
+        	fw = new FileWriter(sutDir + "/" + "CS.json");
+        	fw.write(obj.toJSONString());
+        	fw.flush();
+
+        } catch (IOException e) {
+        	e.printStackTrace();
+        } finally {
+        	if (fw != null) {
+        		try {
+        			fw.close();
+        		} catch (IOException e) {
+        			// TODO Auto-generated catch block
+        			e.printStackTrace();
+        		}
+        	}
+        }
+
+        System.out.print(obj);
+	}
+}

--- a/Command/src/main/java/nato/ivct/commander/Command.java
+++ b/Command/src/main/java/nato/ivct/commander/Command.java
@@ -25,5 +25,5 @@ public interface Command {
 	/**
 	 * the execute method will run in the callers thread. 
 	 */
-	public void execute();
+	public void execute() throws Exception;
 }

--- a/Command/src/main/java/nato/ivct/commander/Factory.java
+++ b/Command/src/main/java/nato/ivct/commander/Factory.java
@@ -353,6 +353,11 @@ public class Factory {
 		return new CmdSendTcVerdict(sutName, sutDir, testScheduleName, testcase, verdict, verdictText);
 	}
 
+	public static CmdUpdateSUT createCmdUpdateSUT(final String sutName, final String sutDescription, final String vendorName, final BadgeTcParam[] badgeTcParams) {
+		initialize();
+		return new CmdUpdateSUT(sutName, sutDescription, vendorName, badgeTcParams);
+	}
+
 	public static int getCmdCounter() {
 		return cmdCounter;
 	}

--- a/UI/src/main/java/de/fraunhofer/iosb/ivct/CmdLineTool.java
+++ b/UI/src/main/java/de/fraunhofer/iosb/ivct/CmdLineTool.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.Semaphore;
 
 import de.fraunhofer.iosb.messaginghelpers.LogConfigurationHelper;
+import nato.ivct.commander.BadgeTcParam;
 import nato.ivct.commander.CmdQuit;
 import nato.ivct.commander.CmdSetLogLevel;
 import nato.ivct.commander.CmdStartTestResultListener;
@@ -36,7 +37,7 @@ import nato.ivct.commander.Factory;
 public class CmdLineTool {
     Thread writer;
 	private boolean keepGoing = true;
-    private Command command = null;
+    private nato.ivct.commander.Command command = null;
 	private Semaphore semaphore = new Semaphore(0);
 	public static Process p;
     public static IVCTcommander ivctCommander;
@@ -99,7 +100,10 @@ public class CmdLineTool {
     			} catch (InterruptedException e) {
     				// TODO Auto-generated catch block
     				e.printStackTrace();
-    			}
+    			} catch (Exception e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
 
     		}
     	}
@@ -194,6 +198,173 @@ class Writer extends Thread {
                 switch(split[0]) {
                 case "":
                 	break;
+                case "addSUT":
+                case "asut":
+                	// Need an input parameter
+                	if (split.length < 2) {
+                        out.println("addSUT: need SUT name");
+                        break;
+                	}
+                	String sutName = split[1];
+                	int posSutName = sutName.indexOf("\"");
+                	if (posSutName != -1) {
+                		out.println("addSUT: SUT name must NOT be quoted: " + line);
+                		break;
+                	}
+                	// check if SUT entered exists in SUT list
+                    if (ivctCommander.rtp.checkSutNotKnown(sutName) == false) {
+                		out.println("addSUT: SUT already exists: " + sutName);
+                		break;
+                	}
+                    int posDesc = line.indexOf("\"");
+                    if (posDesc == -1) {
+                		out.println("addSUT: no description start quote: " + line);
+                		break;
+                    }
+                    int posDescEnd = line.indexOf("\"", posDesc + 1);
+                    if (posDescEnd == -1) {
+                		out.println("addSUT: no description end quote: " + line);
+                		break;
+                    }
+                	if (posDescEnd == posDesc + 1) {
+                		out.println("addSUT: no description: " + line);
+                		break;
+                	}
+                	String sutDescription = line.substring(posDesc + 1, posDescEnd);
+                    int posVen = line.indexOf("\"", posDescEnd + 1);
+                    if (posVen == -1) {
+                		out.println("addSUT: no quoted vendor: " + line);
+                		break;
+                    }
+                    int posVenEnd = line.indexOf("\"", posVen + 1);
+                    if (posVenEnd == -1) {
+                		out.println("addSUT: no vendor start quote: " + sutName);
+                		break;
+                    }
+                	if (posVenEnd == posVen + 1) {
+                		out.println("addSUT: no vendor: " + line);
+                		break;
+                	}
+                	String vendorName = line.substring(posVen + 1, posVenEnd);
+                	command = Factory.createCmdUpdateSUT(sutName, sutDescription, vendorName, null);
+                	try {
+						command.execute();
+					} catch (Exception e2) {
+						// TODO Auto-generated catch block
+						e2.printStackTrace();
+	                	command = null;
+	                	break;
+					}
+                	command = null;
+                    List<String> sutsAsut = ivctCommander.rtp.getSUTS();
+                	if (sutsAsut.isEmpty()) {
+                		out.println("No SUT found. Please load a SUT onto the file system.");
+                		break;
+                	}
+                	ivctCommander.rtp.setSutName(split[1]);
+                    ivctCommander.resetSUT();
+                	break;
+                case "listBadges":
+                case "lbg":
+                	// Warn about extra parameter
+                	if (split.length > 1) {
+                        out.println("listBadges: Warning extra parameter: " + split[1]);
+                	}
+            		List<String> badges = null;
+            		badges = ivctCommander.rtp.getTestSuiteNames();
+            		for (String entry  : badges) {
+                        out.println(entry);
+            		}
+                	break;
+                case "addBadge":
+                case "abg":
+                    if (ivctCommander.rtp.checkSutNotSelected()) {
+                		out.println(sutNotSelected);
+                		break;
+                	}
+                	// Need an input parameter
+                	if (split.length < 2) {
+                        out.println("addBadge: need badge name");
+                        break;
+                	}
+                	List<String> allBadges = ivctCommander.rtp.getTestSuiteNames();
+                	List<String> sutBadges = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName(), false);
+                	boolean errorOccurred = false;
+                	String newBadge = null;
+                	for (int i = 0; i < split.length - 1; i++) {
+                		newBadge = split[i + 1];
+                		if (allBadges.contains(newBadge) == false) {
+                            out.println("addBadge: unknown badge name: " + newBadge);
+                            errorOccurred = true;
+                            break;
+                		}
+                		if (sutBadges.contains(newBadge) == false) {
+                		sutBadges.add(newBadge);
+                		}
+                	}
+                	BadgeTcParam[] badgeTcParams = new BadgeTcParam[sutBadges.size()];
+                	int ind = 0;
+                	for (String Entry : sutBadges) {
+                		if (allBadges.contains(newBadge) == false) {
+                            out.println("addBadge: unknown badge name: " + newBadge);
+                            errorOccurred = true;
+                            break;
+                		}
+                    	badgeTcParams[ind] = new BadgeTcParam();
+                		badgeTcParams[ind].id = new String (Entry);
+                		badgeTcParams[ind].tcParam = null;
+                		ind += 1;
+                	}
+                	if (errorOccurred) {
+                		break;
+                	}
+                	command = Factory.createCmdUpdateSUT(ivctCommander.rtp.getSutName(), ivctCommander.rtp.getSutDescription(), ivctCommander.rtp.getVendorName(), badgeTcParams);
+                	try {
+						command.execute();
+					} catch (Exception e1) {
+						// TODO Auto-generated catch block
+						e1.printStackTrace();
+					}
+                	command = null;
+                	break;
+                case "deleteBadge":
+                case "dbg":
+                	if (ivctCommander.rtp.checkSutNotSelected()) {
+                		out.println(sutNotSelected);
+                		break;
+                	}
+                	// Need an input parameter
+                	if (split.length < 2) {
+                		out.println("deleteBadge: need badge name(s)");
+                		break;
+                	}
+                	List<String> sutBadgesDbg = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName(), false);
+                	String newBadgeDbg = null;
+                	for (int i = 0; i < split.length - 1; i++) {
+                		newBadgeDbg = split[i + 1];
+                		if (sutBadgesDbg.contains(newBadgeDbg) == false) {
+                			out.println("deleteBadge: unknown badge name: " + newBadgeDbg);
+                			break;
+                		}
+            			sutBadgesDbg.remove(newBadgeDbg);
+                	}
+                	BadgeTcParam[] badgeTcParamsDbg = new BadgeTcParam[sutBadgesDbg.size()];
+                	int indDbg = 0;
+                	for (String Entry : sutBadgesDbg) {
+                		badgeTcParamsDbg[indDbg] = new BadgeTcParam();
+                		badgeTcParamsDbg[indDbg].id = new String (Entry);
+                		badgeTcParamsDbg[indDbg].tcParam = null;
+                		indDbg += 1;
+                	}
+                	command = Factory.createCmdUpdateSUT(ivctCommander.rtp.getSutName(), ivctCommander.rtp.getSutDescription(), ivctCommander.rtp.getVendorName(), badgeTcParamsDbg);
+                	try {
+						command.execute();
+					} catch (Exception e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
+                	command = null;
+                	break;
                 case "listSUT":
                 case "lsut":
                 	// Warn about extra parameter
@@ -248,7 +419,7 @@ class Writer extends Thread {
                 	if (split.length > 1) {
                 		out.println("listTestSchedules: Warning extra parameter: " + split[1]);
                 	}
-                	List<String> ls2 = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName());
+                	List<String> ls2 = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName(), true);
                 	for (String temp : ls2) {
                 		System.out.println(temp);
                 	}
@@ -268,7 +439,7 @@ class Writer extends Thread {
                         out.println("startTestSchedule: Warning missing test schedule name");
                         break;
                 	}
-                	List<String> ls1 = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName());
+                	List<String> ls1 = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName(), true);
                 	boolean gotTestSchedule = false;
         			for (String entry : ls1) {
                 		if (split[1].equals(entry)) {
@@ -325,7 +496,7 @@ class Writer extends Thread {
                 	if (split.length > 1) {
                 		out.println("listTestCases: Warning extra parameter: " + split[1]);
                 	}
-                	List<String> ls3 = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName());
+                	List<String> ls3 = ivctCommander.rtp.getSutBadges(ivctCommander.rtp.getSutName(), true);
                 	for (String temp : ls3) {
                 		System.out.println(temp);
                     	List<String> testcases1 = ivctCommander.rtp.getTestcases(temp);
@@ -452,6 +623,10 @@ class Writer extends Thread {
                     System.exit(0);
                 case "help":
                 case "h":
+                    out.println("addSUT (asut) sut \"description text quoted\" \"vendor text quoted\"- add an SUT");
+                    out.println("listBadges (lbg) - list all available badges");
+                    out.println("addBadge (abg) badge ... badge - add one or more badges to SUT");
+                    out.println("deleteBadge (dbg) badge ... badge - delete one or more badges from SUT");
                     out.println("listSUT (lsut) - list SUT folders");
                     out.println("setSUT (ssut) sut - set active SUT");
                     out.println("listTestSchedules (lts) - list the available test schedules for the test suite");
@@ -479,7 +654,11 @@ class Writer extends Thread {
             }
         }
         catch (IOException e) { System.err.println("Writer: " + e); }
-        finally { if (out != null) out.close(); }
+        finally {
+        	if (out != null) {
+        		out.close();
+        	}
+        }
         System.exit(0);
     }
 }

--- a/UI/src/main/java/de/fraunhofer/iosb/ivct/RuntimeParameters.java
+++ b/UI/src/main/java/de/fraunhofer/iosb/ivct/RuntimeParameters.java
@@ -55,6 +55,7 @@ public final class RuntimeParameters {
 	private static String testCaseName = null;
 	private static String testScheduleName = null;
 	private String testSuiteName = null;
+	private CmdListSuT.SutDescription sutDescription;
 
     public RuntimeParameters () {
     }
@@ -101,6 +102,7 @@ public final class RuntimeParameters {
     }
 
 	protected boolean checkSutNotKnown(final String sut) {
+		setSUTS();
         if (sut == null) {
             printStream.println("checkSutNotKnown: SUT: null pointer found");
             return true;
@@ -262,7 +264,7 @@ public final class RuntimeParameters {
 		return suts;
 	}
 
-	protected List<String> getSutBadges(final String theSutName) {
+	protected List<String> getSutBadges(final String theSutName, final boolean recursive) {
 		List<String> badges = null;
 		listSUTs();
 		for (String it: sutList.sutMap.keySet()) {
@@ -276,8 +278,10 @@ public final class RuntimeParameters {
 					if (ind < 0) {
 						badges.add(conformanceStatment[i]);
 					}
-					if (getRecursiveBadges(badges, conformanceStatment[i])) {
-						return null;
+					if (recursive) {
+						if (getRecursiveBadges(badges, conformanceStatment[i])) {
+							return null;
+						}
 					}
 				}
 				return badges;
@@ -327,11 +331,20 @@ public final class RuntimeParameters {
 
 		// Set the sut name.
 		sutName = theSutName;
+		sutDescription = sutList.sutMap.get(sutName);
 
 		// Reset values.
 		testCaseName = null;
 		testScheduleName = null;
 		testSuiteName = null;
+	}
+
+	protected String getSutDescription() {
+		return this.sutDescription.description;
+	}
+
+	protected String getVendorName() {
+		return this.sutDescription.vendor;
 	}
 
 	protected static String getTestCaseName() {

--- a/UI/src/main/java/de/fraunhofer/iosb/ivct/StartTestSchedule.java
+++ b/UI/src/main/java/de/fraunhofer/iosb/ivct/StartTestSchedule.java
@@ -16,7 +16,7 @@ limitations under the License.
 
 package de.fraunhofer.iosb.ivct;
 
-public class StartTestSchedule implements Command {
+public class StartTestSchedule implements nato.ivct.commander.Command {
 	final CommandCache commandCache;
 	final IVCTcommander ivctCommander;
 


### PR DESCRIPTION
Added the logic to create an SUT on the file system. The SUT ID is taken as the name of the sub-directory within the IVCTsut  directory. The SUT ID, SUT description, vendor and badges are written to the SUT CS.json file within the SUT directory. The badges can also be specified and the TcParams.json file for each badge with default values will be copied a sub-directory named after the badge. Badges for an SUT may also be deleted, but a deletion will not delete the sub-directory corresponding to the badge name: only the badges in CS.json are condidered active.