### PR TITLE
Changed order of Logback.configureLogging call to connect to JMS.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+#* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+start.sh text eol=lf
+
+# Denote all files that should not be modified.
+#*.java -text
+
+# Denote all files that are truly binary and should not be modified.
+#*.png binary
+#*.jpg binary

--- a/TC.exec/src/main/java/de/fraunhofer/iosb/testrunner/JMSTestRunner.java
+++ b/TC.exec/src/main/java/de/fraunhofer/iosb/testrunner/JMSTestRunner.java
@@ -61,8 +61,6 @@ public class JMSTestRunner extends TestRunner
 	 *            The command line arguments
 	 */
 	public static void main(final String[] args) {
-		// LogConfigurationHelper.configureLogging(JMSTestRunner.class);
-		LogConfigurationHelper.configureLogging();
 		try {
 			final JMSTestRunner runner = new JMSTestRunner();
 		} catch (final IOException ex) {
@@ -80,6 +78,9 @@ public class JMSTestRunner extends TestRunner
 
 		// initialize the IVCT Commander Factory
 		Factory.initialize();
+
+		// Configure the logger
+		LogConfigurationHelper.configureLogging();
 
 		// start command listeners
 		(new CmdSetLogLevelListener(this)).execute();


### PR DESCRIPTION
Now have a stable .gitattributes file which does not cause problems with *.java files. Changed order of Logback configureLogging call so that connection to JMS can be done more reliably.